### PR TITLE
feat: Propagator.providers() — 让 Propagator 能给 subscriber 注入自定义 Provider

### DIFF
--- a/arclet/letoderea/subscriber.py
+++ b/arclet/letoderea/subscriber.py
@@ -191,6 +191,9 @@ class Propagator(metaclass=abc.ABCMeta):
     def validate(self, subscriber: Subscriber) -> bool:
         return True
 
+    def providers(self) -> list[Provider | ProviderFactory]:
+        return []
+
     def __iter__(self):  # pragma: no cover
         return self.compose()
 
@@ -398,6 +401,10 @@ class Subscriber(Generic[R]):
         if isinstance(func, Propagator):
             if not func.validate(self):
                 return lambda: None
+            extra_providers = func.providers()
+            if extra_providers:
+                self.providers.extend(extra_providers)
+                self._recompile()
             disposes = []
             for slot in func.compose():
                 if isinstance(slot, Propagator):


### PR DESCRIPTION
给 Propagator 加了个 `providers()` 方法，这样 Propagator 可以给 subscriber 注入自定义的 Provider。

之前 propagator 往 context 里塞自定义类型的对象，subscriber 只能靠参数名对上才能拿到。现在 propagator 可以声明自己的 providers，subscriber 就能直接按类型标注拿到了。

## Changes

- `Propagator` 新增 `providers()` 方法，默认返回空列表，向后兼容
- `Subscriber.propagate()` 接入 Propagator 时自动调用 `providers()`，把返回的 Provider/ProviderFactory 注册到 subscriber 上并 recompile

## 用法

```python
from dataclasses import dataclass

@dataclass
class MatchResult:
    text: str

class MyPropagator(Propagator):
    def compose(self):
        def check(foo: str):
            return {"_result": MatchResult(text=foo.upper())}
        yield check, True

    def providers(self):
        return [provide(MatchResult, target="_result", call=lambda ctx: ctx.get("_result"))]

@leto.on(SomeEvent)
@subscriber.propagate(MyPropagator())
async def handler(result: MatchResult):
    print(result.text)  # 按类型注入，不用管参数名
```

## Tests

4 个新用例，全量 40 通过
